### PR TITLE
Override this.props with custom props if prop value is equal to defau…

### DIFF
--- a/src/CustomFunctions/setCustomText.js
+++ b/src/CustomFunctions/setCustomText.js
@@ -4,9 +4,17 @@ import {
 
 export const setCustomText = customProps => {
   const textRender = Text.prototype.render;
+  const defaultProps = Text.defaultProps;
   Text.prototype.render = function render() {
     let oldProps = this.props;
-    this.props = { ...customProps, ...this.props, style: [customProps.style, this.props.style] };
+    let defaultPropsOverride = {};
+    Object.entries(customProps).forEach( entry => {
+      const [k, v] = entry;
+      if(oldProps[k] === defaultProps[k]) {
+        defaultPropsOverride[k] = v;
+      }
+    });
+    this.props = { ...customProps, ...this.props, ...defaultPropsOverride, style: [customProps.style, this.props.style] };
     try {
       return textRender.apply(this, arguments);
     } finally {


### PR DESCRIPTION
Hello,

I had an issue with this code 

`const globalTextProps = {
  allowFontScaling: false,
};
setCustomText(globalTextProps);`

allowFontScaling is a default prop on Text component, the current implementation do not allow a custom value if a default value is defined on the component.

for each custom prop, I now compare the current value with the default value and use the custom prop if it's equal